### PR TITLE
build.properties in license feature build

### DIFF
--- a/org.palladiosimulator.license/build.properties
+++ b/org.palladiosimulator.license/build.properties
@@ -1,2 +1,3 @@
 bin.includes = feature.xml,\
-               feature.properties
+               feature.properties,\
+               build.properties


### PR DESCRIPTION
The `build.properties` of the `org.palladiosimulator.license` feature were not included in the build yet.
Using a Maven Tycho-based build process, this file is required in the deployed license feature.
Therefore, this PR adds the respective file to the feature build.